### PR TITLE
fix(docs): add `Move` section to README and improve README readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 </button>
 ```
 
-
 <details>
     <summary>
-        <h3>`createPress`</h3>
+        <div>
+            `createPress`
+        </div>
     </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -67,9 +68,10 @@ Creates a new `press` interaction instance. Each element should have its own ins
 ```
 
 </details>
+
 <details>
     <summary>
-        <h3>PressConfig</h3>
+        <div>PressConfig</div>
     </summary>
 
 `createPress` takes in an optional `PressConfig` object, which can be used to customize the interaction.
@@ -161,9 +163,10 @@ type PressHandlers = {
 ```
 
 </details>
+
 <details>
     <summary>
-        <h3>PressResult</h3>
+        <div>PressResult</div>
     </summary>
 
 The `createPress` function returns a `PressResult` object, which contains the `pressAction` action, and the `isPressed` state. More returned properties may be added in the future if needed.
@@ -178,9 +181,10 @@ type PressResult = {
 ```
 
 </details>
+
 <details>
     <summary>
-        <h3>CustomEvent</h3>
+        <div>CustomEvent</div>
     </summary>
 
 When you apply the `pressAction` to an element, it will dispatch custom `on:press*` events. You can use these or the `PressHandlers` to handle the various press events.
@@ -215,9 +219,10 @@ type PressActionReturn = ActionReturn<
 ```
 
 </details>
+
 <details>
     <summary>
-        <h3>PressEvent</h3>
+        <div>PressEvent</div>
     </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
@@ -283,7 +288,7 @@ The `hover` interaction provides an API for consistent long press behavior acros
 
 <details>
     <summary>
-        <h3>`createLongPress`</h3>
+        <div>`createLongPress`</div>
     </summary>
 
 Creates a new `longpress` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -304,7 +309,7 @@ Creates a new `longpress` interaction instance. Each element should have its own
 
 <details>
     <summary>
-        <h3>LongPressConfig</h3>
+        <div>LongPressConfig</div>
     </summary>
 
 `createLongPress` takes in an optional `LongPressConfig` object, which can be used to customize the interaction.
@@ -365,7 +370,7 @@ export type LongPressHandlers = {
 
 <details>
     <summary>
-        <h3>LongPressResult</h3>
+        <div>LongPressResult</div>
     </summary>
 
 The `createLongPress` function returns a `LongPressResult` object, which contains the `longPressAction` action, and the `description` state. More returned properties may be added in the future if needed.
@@ -393,7 +398,7 @@ type LongPressResult = {
 
 <details>
     <summary>
-        <h3>Custom Events</h3>
+        <div>Custom Events</div>
     </summary>
 
 When you apply the `longPressAction` to an element, it will dispatch custom `on:longpress*` events for events you aren't handling via the `LongPressConfig` props. You can use these or the `LongPressHandlers` to handle the various `longpress` events.
@@ -426,7 +431,7 @@ type LongPressActionReturn = ActionReturn<
 
 <details>
     <summary>
-        <h3>PressEvent</h3>
+        <div>PressEvent</div>
     </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
@@ -488,7 +493,7 @@ The `hover` interaction provides an API for consistent hover behavior across all
 
 <details>
     <summary>
-        <h3>`createHover`</h3>
+        <div>`createHover`</div>
     </summary>
 
 Creates a new `hover` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple elements you wanted to apply hover state to on a page:
@@ -509,7 +514,7 @@ Creates a new `hover` interaction instance. Each element should have its own ins
 
 <details>
     <summary>
-        <h3>HoverConfig</h3>
+        <div>HoverConfig</div>
     </summary>
 
 The `createHover` function takes in an optional `HoverConfig` object, which can be used to customize the interaction.
@@ -556,7 +561,7 @@ type HoverHandlers = {
 
 <details>
     <summary>
-        <h3>HoverResult</h3>
+        <div>HoverResult</div>
     </summary>
 
 The `createHover` function returns a `HoverResult` object, which contains the `hoverAction` action, and the `isHovering` state. More returned properties may be added in the future if needed.
@@ -580,7 +585,7 @@ export type HoverResult = {
 
 <details>
     <summary>
-        <h3>Custom Events</h3>
+        <div>Custom Events</div>
     </summary>
 
 When you apply the `hoverAction` to an element, it will dispatch custom `on:hover*` events. You can use these or the `HoverHandlers` to handle the various hover events.
@@ -606,7 +611,7 @@ type HoverActionReturn = ActionReturn<
 
 <details>
     <summary>
-        <h3>HoverEvent</h3>
+        <div>HoverEvent</divn>
     </summary>
 
 This is the event object dispatched by the custom `on:hover*` events, and is also passed to the `HoverHandlers` should you choose to use them.
@@ -626,7 +631,7 @@ interface HoverEvent {
 
 ## Move Interaction
 
-The `move` interaction provides an API for consistent move behavior across all browsers and devices, ignoring emulated mouse events on touch devices.
+Handles `move` interactions across mouse, touch, and keyboard, including dragging with the mouse or touch, and using the arrow keys. Normalizes behavior across browsers and platforms, and ignores emulated mouse events on touch devices.
 
 #### Basic Usage
 
@@ -650,3 +655,23 @@ The `move` interaction provides an API for consistent move behavior across all b
 </button>
 ```
 
+<details>
+    <summary>
+        <div>
+            `createMove`
+        </div>
+    </summary>
+
+Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
+
+```svelte
+<script lang="ts">
+	import { createMove } from 'svelte-interactions';
+
+	const { moveAction } = createMove();
+</script>
+
+<div use:moveAction on:move> Moveable Area </div>
+```
+
+</details>

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 </button>
 ```
 
-<details>
-    <summary>
-        <h3>createPress</h3>
-    </summary>
+
+### createPress
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
 
@@ -65,9 +63,10 @@ Creates a new `press` interaction instance. Each element should have its own ins
 <button use:pressTwo on:press> Button Two </button>
 ```
 
-</details>
-
-#### PressConfig
+<details>
+    <summary>
+        <h3>PressConfig</h3>
+    </summary>
 
 `createPress` takes in an optional `PressConfig` object, which can be used to customize the interaction.
 
@@ -157,7 +156,12 @@ type PressHandlers = {
 };
 ```
 
-### PressResult
+</details>
+
+<details>
+    <summary>
+        <h3>PressResult</h3>
+    </summary>
 
 The `createPress` function returns a `PressResult` object, which contains the `pressAction` action, and the `isPressed` state. More returned properties may be added in the future if needed.
 
@@ -170,7 +174,12 @@ type PressResult = {
 };
 ```
 
-### Custom Events
+</details>
+
+<details>
+    <summary>
+        <h3>CustomEvent</h3>
+    </summary>
 
 When you apply the `pressAction` to an element, it will dispatch custom `on:press*` events. You can use these or the `PressHandlers` to handle the various press events.
 
@@ -203,7 +212,12 @@ type PressActionReturn = ActionReturn<
 >;
 ```
 
-#### PressEvent
+</details>
+
+<details>
+    <summary>
+        <h3>PressEvent</h3>
+    </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
 
@@ -241,6 +255,8 @@ interface PressEvent {
 }
 ```
 
+</details>
+
 ## Long Press Interaction
 
 The `hover` interaction provides an API for consistent long press behavior across all browsers and devices, with support for a custom time threshold and accessible description.
@@ -264,7 +280,10 @@ The `hover` interaction provides an API for consistent long press behavior acros
 </button>
 ```
 
-### createLongPress
+<details>
+    <summary>
+        <h3>createLongPress</h3>
+    </summary>
 
 Creates a new `longpress` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
 
@@ -280,7 +299,12 @@ Creates a new `longpress` interaction instance. Each element should have its own
 <button use:longPressTwo on:longpress> Button Two </button>
 ```
 
-#### LongPressConfig
+</details>
+
+<details>
+    <summary>
+        <h3>LongPressConfig</h3>
+    </summary>
 
 `createLongPress` takes in an optional `LongPressConfig` object, which can be used to customize the interaction.
 
@@ -336,7 +360,12 @@ export type LongPressHandlers = {
 };
 ```
 
-### LongPressResult
+</details>
+
+<details>
+    <summary>
+        <h3>LongPressResult</h3>
+    </summary>
 
 The `createLongPress` function returns a `LongPressResult` object, which contains the `longPressAction` action, and the `description` state. More returned properties may be added in the future if needed.
 
@@ -359,7 +388,12 @@ type LongPressResult = {
 };
 ```
 
-### Custom Events
+</details>
+
+<details>
+    <summary>
+        <h3>Custom Events</h3>
+    </summary>
 
 When you apply the `longPressAction` to an element, it will dispatch custom `on:longpress*` events for events you aren't handling via the `LongPressConfig` props. You can use these or the `LongPressHandlers` to handle the various `longpress` events.
 
@@ -387,7 +421,12 @@ type LongPressActionReturn = ActionReturn<
 >;
 ```
 
-#### PressEvent
+</details>
+
+<details>
+    <summary>
+        <h3>PressEvent</h3>
+    </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
 
@@ -418,6 +457,8 @@ interface PressEvent {
 }
 ```
 
+</details>
+
 ## Hover Interaction
 
 The `hover` interaction provides an API for consistent hover behavior across all browsers and devices, ignoring emulated mouse events on touch devices.
@@ -444,7 +485,10 @@ The `hover` interaction provides an API for consistent hover behavior across all
 </button>
 ```
 
-### createHover
+<details>
+    <summary>
+        <h3>createHover</h3>
+    </summary>
 
 Creates a new `hover` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple elements you wanted to apply hover state to on a page:
 
@@ -460,7 +504,12 @@ Creates a new `hover` interaction instance. Each element should have its own ins
 <div use:hoverTwo on:hoverstart>Hoverable element two</div>
 ```
 
-#### HoverConfig
+</details>
+
+<details>
+    <summary>
+        <h3>HoverConfig</h3>
+    </summary>
 
 The `createHover` function takes in an optional `HoverConfig` object, which can be used to customize the interaction.
 
@@ -502,7 +551,12 @@ type HoverHandlers = {
 };
 ```
 
-### HoverResult
+</details>
+
+<details>
+    <summary>
+        <h3>HoverResult</h3>
+    </summary>
 
 The `createHover` function returns a `HoverResult` object, which contains the `hoverAction` action, and the `isHovering` state. More returned properties may be added in the future if needed.
 
@@ -521,7 +575,12 @@ export type HoverResult = {
 };
 ```
 
-### Custom Events
+</details>
+
+<details>
+    <summary>
+        <h3>Custom Events</h3>
+    </summary>
 
 When you apply the `hoverAction` to an element, it will dispatch custom `on:hover*` events. You can use these or the `HoverHandlers` to handle the various hover events.
 
@@ -542,7 +601,12 @@ type HoverActionReturn = ActionReturn<
 >;
 ```
 
-#### HoverEvent
+</details>
+
+<details>
+    <summary>
+        <h3>HoverEvent</h3>
+    </summary>
 
 This is the event object dispatched by the custom `on:hover*` events, and is also passed to the `HoverHandlers` should you choose to use them.
 
@@ -556,3 +620,5 @@ interface HoverEvent {
 	target: Element;
 }
 ```
+
+</details>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ npm install svelte-interactions
 ## Table of Contents
 
 - [Press Interaction](#press-interaction)
-- [Press Interaction](#press-interaction)
-- [Press Interaction](#press-interaction)
-- [Press Interaction](#press-interaction)
+- [Long Press Interaction](#long-press-interaction)
+- [Hover Interaction](#hover-interaction)
+- [Move Interaction](#move-interaction)
 
 ## Press Interaction
 

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Handles `move` interactions across mouse, touch, and keyboard, including draggin
 	const { moveAction } = createMove();
 </script>
 
-<button
+<div
 	use:moveAction
 	on:movestart={(e) => {
 		console.log('you just started moving me!', e);
@@ -649,8 +649,8 @@ Handles `move` interactions across mouse, touch, and keyboard, including draggin
 		console.log('you just stopped moving me!', e);
 	}}
 >
-	Press Me
-</button>
+	Moveable Area
+</div>
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 
 <details>
     <summary>
-### createPress
+        <h3>createPress</h3>
     </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Creates a new `press` interaction instance. Each element should have its own ins
 	const { moveAction } = createMove();
 </script>
 
-<div use:moveAction on:move> Moveable Area </div>
+<div use:moveAction on:move>Moveable Area</div>
 ```
 
 </details>
@@ -678,7 +678,7 @@ Creates a new `press` interaction instance. Each element should have its own ins
     </summary>
 
 ```ts
-export type MoveConfig = MoveHandlers & { }
+export type MoveConfig = MoveHandlers & {};
 ```
 
 The `MoveConfig` object also includes handlers for all the different `MoveHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:move*` events dispatched by the element with the `moveAction`.
@@ -701,7 +701,7 @@ export type MoveHandlers = {
 	 * Handler that is called when the element is moved.
 	 */
 	onMove?: (e: MoveMoveEvent) => void;
-}
+};
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 
 <details>
     <summary>
-        <div>
-            `createPress`
-        </div>
+        <span> createPress </span>
     </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -71,7 +69,7 @@ Creates a new `press` interaction instance. Each element should have its own ins
 
 <details>
     <summary>
-        <div>PressConfig</div>
+        <span>PressConfig</span>
     </summary>
 
 `createPress` takes in an optional `PressConfig` object, which can be used to customize the interaction.
@@ -83,7 +81,7 @@ const { pressAction } = createPress({ isDisabled: true });
 ```
 
 ```ts
-type PressConfig = PressHandlers {
+type PressConfig = PressHandlers & {
 	/**
 	 * Whether the target is in a controlled press state
 	 * (e.g. an overlay it triggers is open).
@@ -129,7 +127,7 @@ type PressConfig = PressHandlers {
 
 The `PressConfig` object also includes handlers for all the different `PressHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:press*` events dispatched by the element with the `pressAction`.
 
-Be aware that event if you use these handlers, the custom `on:press*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `PressHandlers`.
+Be aware that even if you use these handlers, the custom `on:press*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `PressHandlers`.
 
 ```ts
 type PressHandlers = {
@@ -166,7 +164,7 @@ type PressHandlers = {
 
 <details>
     <summary>
-        <div>PressResult</div>
+        <span>PressResult</span>
     </summary>
 
 The `createPress` function returns a `PressResult` object, which contains the `pressAction` action, and the `isPressed` state. More returned properties may be added in the future if needed.
@@ -184,7 +182,7 @@ type PressResult = {
 
 <details>
     <summary>
-        <div>CustomEvent</div>
+        <span>CustomEvent</span>
     </summary>
 
 When you apply the `pressAction` to an element, it will dispatch custom `on:press*` events. You can use these or the `PressHandlers` to handle the various press events.
@@ -222,7 +220,7 @@ type PressActionReturn = ActionReturn<
 
 <details>
     <summary>
-        <div>PressEvent</div>
+        <span>PressEvent</span>
     </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
@@ -288,7 +286,7 @@ The `hover` interaction provides an API for consistent long press behavior acros
 
 <details>
     <summary>
-        <div>`createLongPress`</div>
+        <span>createLongPress</span>
     </summary>
 
 Creates a new `longpress` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -309,7 +307,7 @@ Creates a new `longpress` interaction instance. Each element should have its own
 
 <details>
     <summary>
-        <div>LongPressConfig</div>
+        <span>LongPressConfig</span>
     </summary>
 
 `createLongPress` takes in an optional `LongPressConfig` object, which can be used to customize the interaction.
@@ -343,7 +341,7 @@ type LongPressConfig = LongPressHandlers & {
 
 The `LongPressConfig` object also includes handlers for all the different `LongPressHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:longpress*` events dispatched by the element with the `longPressAction`.
 
-Be aware that event if you use these handlers, the custom `on:longpress*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `LongPressHandlers`.
+Be aware that even if you use these handlers, the custom `on:longpress*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `LongPressHandlers`.
 
 ```ts
 export type LongPressHandlers = {
@@ -370,7 +368,7 @@ export type LongPressHandlers = {
 
 <details>
     <summary>
-        <div>LongPressResult</div>
+        <span>LongPressResult</span>
     </summary>
 
 The `createLongPress` function returns a `LongPressResult` object, which contains the `longPressAction` action, and the `description` state. More returned properties may be added in the future if needed.
@@ -398,7 +396,7 @@ type LongPressResult = {
 
 <details>
     <summary>
-        <div>Custom Events</div>
+        <span>Custom Events</span>
     </summary>
 
 When you apply the `longPressAction` to an element, it will dispatch custom `on:longpress*` events for events you aren't handling via the `LongPressConfig` props. You can use these or the `LongPressHandlers` to handle the various `longpress` events.
@@ -431,7 +429,7 @@ type LongPressActionReturn = ActionReturn<
 
 <details>
     <summary>
-        <div>PressEvent</div>
+        <span>PressEvent</span>
     </summary>
 
 This is the event object dispatched by the custom `on:press*` events, and is also passed to the `PressHandlers` should you choose to use them.
@@ -493,7 +491,7 @@ The `hover` interaction provides an API for consistent hover behavior across all
 
 <details>
     <summary>
-        <div>`createHover`</div>
+        <span>createHover</span>
     </summary>
 
 Creates a new `hover` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple elements you wanted to apply hover state to on a page:
@@ -514,7 +512,7 @@ Creates a new `hover` interaction instance. Each element should have its own ins
 
 <details>
     <summary>
-        <div>HoverConfig</div>
+        <span>HoverConfig</span>
     </summary>
 
 The `createHover` function takes in an optional `HoverConfig` object, which can be used to customize the interaction.
@@ -536,7 +534,7 @@ type HoverConfig = HoverHandlers & {
 
 The `HoverConfig` object also includes handlers for all the different `HoverHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:hover*` events dispatched by the element with the `hoverAction`.
 
-Be aware that event if you use these handlers, the custom `on:hover*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `HoverHandlers`.
+Be aware that even if you use these handlers, the custom `on:hover*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `HoverHandlers`.
 
 ```ts
 type HoverHandlers = {
@@ -561,7 +559,7 @@ type HoverHandlers = {
 
 <details>
     <summary>
-        <div>HoverResult</div>
+        <span>HoverResult</span>
     </summary>
 
 The `createHover` function returns a `HoverResult` object, which contains the `hoverAction` action, and the `isHovering` state. More returned properties may be added in the future if needed.
@@ -585,7 +583,7 @@ export type HoverResult = {
 
 <details>
     <summary>
-        <div>Custom Events</div>
+        <span>Custom Events</span>
     </summary>
 
 When you apply the `hoverAction` to an element, it will dispatch custom `on:hover*` events. You can use these or the `HoverHandlers` to handle the various hover events.
@@ -611,7 +609,7 @@ type HoverActionReturn = ActionReturn<
 
 <details>
     <summary>
-        <div>HoverEvent</divn>
+        <span>HoverEvent</span>
     </summary>
 
 This is the event object dispatched by the custom `on:hover*` events, and is also passed to the `HoverHandlers` should you choose to use them.
@@ -657,9 +655,7 @@ Handles `move` interactions across mouse, touch, and keyboard, including draggin
 
 <details>
     <summary>
-        <div>
-            `createMove`
-        </div>
+        <span>createMove</span>
     </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -672,6 +668,130 @@ Creates a new `press` interaction instance. Each element should have its own ins
 </script>
 
 <div use:moveAction on:move> Moveable Area </div>
+```
+
+</details>
+
+<details>
+    <summary>
+        <span>MoveConfig</span>
+    </summary>
+
+```ts
+export type MoveConfig = MoveHandlers & { }
+```
+
+The `MoveConfig` object also includes handlers for all the different `MoveHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:move*` events dispatched by the element with the `moveAction`.
+
+Be aware that even if you use these handlers, the custom `on:move*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `MoveHandlers`.
+
+```ts
+export type MoveHandlers = {
+	/**
+	 * Handler that is called when a move interaction starts.
+	 */
+	onMoveStart?: (e: MoveStartEvent) => void;
+
+	/**
+	 * Handler that is called when a move interaction ends.
+	 */
+	onMoveEnd?: (e: MoveEndEvent) => void;
+
+	/**
+	 * Handler that is called when the element is moved.
+	 */
+	onMove?: (e: MoveMoveEvent) => void;
+}
+```
+
+</details>
+
+<details>
+    <summary>
+        <span>MoveResult</span>
+    </summary>
+
+The `createMove` function returns a `MoveResult` object, which contains the `moveAction` action. More returned properties may be added in the future if needed.
+
+```ts
+export type MoveResult = {
+	/**
+	 * A Svelte action which handles applying the event listeners
+	 * and dispatching events to the element
+	 */
+	moveAction: (node: HTMLElement | SVGElement) => MoveActionReturn;
+};
+```
+
+</details>
+
+<details>
+    <summary>
+        <span>Custom Events</span>
+    </summary>
+
+When you apply the `moveAction` to an element, it will dispatch custom `on:move*` events. You can use these or the `MoveHandlers` to handle the various move events.
+
+```ts
+type MoveActionReturn = ActionReturn<
+	undefined,
+	{
+		'on:move'?: (e: CustomEvent<MoveMoveEvent>) => void;
+		'on:movestart'?: (e: CustomEvent<MoveStartEvent>) => void;
+		'on:moveend'?: (e: CustomEvent<MoveEndEvent>) => void;
+	}
+>;
+```
+
+</details>
+
+<details>
+    <summary>
+        <span>MoveEvent</span>
+    </summary>
+
+This is the event object dispatched by the custom `on:move*` events, and is also passed to the `MoveHandlers` should you choose to use them.
+
+```ts
+export interface BaseMoveEvent {
+	/** The pointer type that triggered the move event. */
+	pointerType: PointerType;
+
+	/** Whether the shift keyboard modifier was held during the move event. */
+	shiftKey: boolean;
+
+	/** Whether the ctrl keyboard modifier was held during the move event. */
+	ctrlKey: boolean;
+
+	/** Whether the meta keyboard modifier was held during the move event. */
+	metaKey: boolean;
+
+	/** Whether the alt keyboard modifier was held during the move event. */
+	altKey: boolean;
+}
+
+export interface MoveStartEvent extends BaseMoveEvent {
+	/** The type of move event being fired. */
+	type: 'movestart';
+}
+
+export interface MoveMoveEvent extends BaseMoveEvent {
+	/** The type of move event being fired. */
+	type: 'move';
+
+	/** The amount moved in the X direction since the last event. */
+	deltaX: number;
+
+	/** The amount moved in the Y direction since the last event. */
+	deltaY: number;
+}
+
+export interface MoveEndEvent extends BaseMoveEvent {
+	/** The type of move event being fired. */
+	type: 'moveend';
+}
+
+export type MoveEvent = MoveStartEvent | MoveMoveEvent | MoveEndEvent;
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ type PressConfig = PressHandlers & {
 
 The `PressConfig` object also includes handlers for all the different `PressHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:press*` events dispatched by the element with the `pressAction`.
 
-Be aware that even if you use these handlers, the custom `on:press*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `PressHandlers`.
+Be aware that if you use these handlers, the custom `on:press*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `PressHandlers`.
 
 ```ts
 type PressHandlers = {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ While this project is still in its infancy, it'll be documented here. It will ev
 npm install svelte-interactions
 ```
 
+## Table of Contents
+
+- [Press Interaction](#press-interaction)
+- [Press Interaction](#press-interaction)
+- [Press Interaction](#press-interaction)
+- [Press Interaction](#press-interaction)
+
 ## Press Interaction
 
 The `press` interaction is used to implement buttons, links, and other pressable elements. It handles mouse, touch, and keyboard interactions, and ensures that the element is accessible to screen readers and keyboard users.
@@ -39,7 +46,10 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 </button>
 ```
 
+<details>
+    <summary>
 ### createPress
+    </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
 
@@ -54,6 +64,8 @@ Creates a new `press` interaction instance. Each element should have its own ins
 <button use:pressOne on:press> Button One </button>
 <button use:pressTwo on:press> Button Two </button>
 ```
+
+</details>
 
 #### PressConfig
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ No more having to wrangle all those event handlers yourself! Just and use the `p
 ```
 
 
-### createPress
+<details>
+    <summary>
+        <h3>`createPress`</h3>
+    </summary>
 
 Creates a new `press` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
 
@@ -63,6 +66,7 @@ Creates a new `press` interaction instance. Each element should have its own ins
 <button use:pressTwo on:press> Button Two </button>
 ```
 
+</details>
 <details>
     <summary>
         <h3>PressConfig</h3>
@@ -157,7 +161,6 @@ type PressHandlers = {
 ```
 
 </details>
-
 <details>
     <summary>
         <h3>PressResult</h3>
@@ -175,7 +178,6 @@ type PressResult = {
 ```
 
 </details>
-
 <details>
     <summary>
         <h3>CustomEvent</h3>
@@ -213,7 +215,6 @@ type PressActionReturn = ActionReturn<
 ```
 
 </details>
-
 <details>
     <summary>
         <h3>PressEvent</h3>
@@ -282,7 +283,7 @@ The `hover` interaction provides an API for consistent long press behavior acros
 
 <details>
     <summary>
-        <h3>createLongPress</h3>
+        <h3>`createLongPress`</h3>
     </summary>
 
 Creates a new `longpress` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple buttons on a page:
@@ -487,7 +488,7 @@ The `hover` interaction provides an API for consistent hover behavior across all
 
 <details>
     <summary>
-        <h3>createHover</h3>
+        <h3>`createHover`</h3>
     </summary>
 
 Creates a new `hover` interaction instance. Each element should have its own instance, as it maintains state for a single element. For example, if you had multiple elements you wanted to apply hover state to on a page:
@@ -622,3 +623,30 @@ interface HoverEvent {
 ```
 
 </details>
+
+## Move Interaction
+
+The `move` interaction provides an API for consistent move behavior across all browsers and devices, ignoring emulated mouse events on touch devices.
+
+#### Basic Usage
+
+```svelte
+<script lang="ts">
+	import { createMove } from 'svelte-interactions';
+
+	const { moveAction } = createMove();
+</script>
+
+<button
+	use:moveAction
+	on:movestart={(e) => {
+		console.log('you just started moving me!', e);
+	}}
+	on:moveend={(e) => {
+		console.log('you just stopped moving me!', e);
+	}}
+>
+	Press Me
+</button>
+```
+

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ type LongPressConfig = LongPressHandlers & {
 
 The `LongPressConfig` object also includes handlers for all the different `LongPressHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:longpress*` events dispatched by the element with the `longPressAction`.
 
-Be aware that even if you use these handlers, the custom `on:longpress*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `LongPressHandlers`.
+Be aware that if you use these handlers, the custom `on:longpress*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `LongPressHandlers`.
 
 ```ts
 export type LongPressHandlers = {
@@ -534,7 +534,7 @@ type HoverConfig = HoverHandlers & {
 
 The `HoverConfig` object also includes handlers for all the different `HoverHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:hover*` events dispatched by the element with the `hoverAction`.
 
-Be aware that even if you use these handlers, the custom `on:hover*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `HoverHandlers`.
+Be aware that if you use these handlers, the custom `on:hover*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `HoverHandlers`.
 
 ```ts
 type HoverHandlers = {
@@ -683,7 +683,7 @@ export type MoveConfig = MoveHandlers & { }
 
 The `MoveConfig` object also includes handlers for all the different `MoveHandlers`. These are provided as a convenience, should you prefer to handle the events here rather than the custom `on:move*` events dispatched by the element with the `moveAction`.
 
-Be aware that even if you use these handlers, the custom `on:move*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `MoveHandlers`.
+Be aware that if you use these handlers, the custom `on:move*` events for whatever handlers you use will not be dispatched to the element. We only dispatch the events that aren't handled by the `MoveHandlers`.
 
 ```ts
 export type MoveHandlers = {


### PR DESCRIPTION
### [Rendered](https://github.com/ndom91/svelte-interactions/blob/ndom91/readme-cleanup/README.md)

- Add `<summary />` / `<detail />` sections around all sub-sections to improve readability
- Add `Move` docs section

It won't let me tag you as reviewer for whatever reason :thinking: @huntabyte 

Preview screenshot:

![image](https://github.com/svecosystem/svelte-interactions/assets/7415984/08583780-2152-4fdd-a2b3-8c6facfada23)
